### PR TITLE
Clean up newline endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A Python service and REST API for fetching electricity pricing data from multipl
 1. **Clone the repository** (if not already done):
    ```bash
    git clone <your-repo-url>
-   cd pricing-and-optimiser
+   cd pricing-api
    ```
 
 2. **Install dependencies** using uv:

--- a/example_usage.py
+++ b/example_usage.py
@@ -269,4 +269,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/pricing_api.py
+++ b/pricing_api.py
@@ -377,4 +377,4 @@ async def get_current_prices(
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000) 
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/pricing_service.py
+++ b/pricing_service.py
@@ -331,4 +331,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/template_config.yaml
+++ b/template_config.yaml
@@ -87,4 +87,4 @@ service:
   output:
     include_statistics: true
     include_time_columns: true
-    timezone_conversion: true 
+    timezone_conversion: true


### PR DESCRIPTION
## Summary
- fix trailing spaces and newline endings in example_usage.py, pricing_api.py, pricing_service.py and config
- correct repository path in README install instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6852a9a189dc832180e744ecce53caf3